### PR TITLE
Fix installation issue when upgrading from an old version

### DIFF
--- a/_build/resolvers/resolve.cleanup.php
+++ b/_build/resolvers/resolve.cleanup.php
@@ -135,7 +135,9 @@ if ($object->xpdo) {
                         $countPlacements++;
                     }
                 }
-                $oldWidget->remove();
+                if ($oldWidget) {
+                    $oldWidget->remove();
+                }
 
                 if ($countPlacements) {
                     $modx->log(xPDO::LOG_LEVEL_INFO, 'Changed ' . $countPlacements . ' legacy widget placements and removed the legacy widget.');


### PR DESCRIPTION
This code only runs when a version of BackupMODX pre-3.0 exists, but when that version does not have the oldWidget for some reason the resolver breaks the installation. 